### PR TITLE
Fix typos across shell scripts

### DIFF
--- a/bin/.tm.boot.sh
+++ b/bin/.tm.boot.sh
@@ -11,7 +11,7 @@ export TM_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
 export TM_BIN="$TM_HOME/bin"
 export TM_LIB_BASH="$TM_HOME/lib-shared/tm/bash"
 
-# prefix seperator
+# prefix separator
 # for plugin names
 __TM_SEP_PREFIX_NAME=":"
 # for dirs (s we can't use the above)

--- a/bin/.tm.plugin.sh
+++ b/bin/.tm.plugin.sh
@@ -7,7 +7,7 @@
 #   - Enabling and disabling plugins (_tm::plugin::enable, _tm::plugin::__disable).
 #   - Discovering scripts within plugins (_tm::plugin::__find_scripts_in).
 #   - Generating command wrapper scripts for plugins (_tm::plugin::__generate_wrapper_scripts).
-#   - Parsing qualified plugin names with prefixs (_tm::util::parse::plugin_name).
+#   - Parsing qualified plugin names with prefixes (_tm::util::parse::plugin_name).
 #
 
 
@@ -406,7 +406,7 @@ _tm::plugin::__generate_wrapper_scripts() {
     return
   fi
 
-  # prefixs allows us to have a single plugin install, but multiple representations of it with different config
+  # prefixes allow us to have a single plugin install, but multiple representations of it with different config
   local prefix="${plugin_generate[prefix]}"
   local vendor="${plugin_generate[vendor]}"
   local plugin_name="${plugin_generate[name]}"

--- a/bin/tm-space-create
+++ b/bin/tm-space-create
@@ -9,7 +9,7 @@ declare -A args
 _parse_args \
     --file "${BASH_SOURCE[0]}" \
     --help-tip \
-    --opt-key "|remainder|short=k|value=NAME|desc=The space key (namespace, dot seperated, no spaces)|validators=space-key" \
+    --opt-key "|remainder|short=k|value=NAME|desc=The space key (namespace, dot separated, no spaces)|validators=space-key" \
     --opt-guid "|short=g|value=GUID|desc=The space guid" \
     --opt-label "|short=l|value=LABEL|desc=The human friendly space label" \
     --opt-parent-key "|multi|short=pk|value=KEY|desc=The parent key|validators=space-key" \

--- a/lib-shared/tm/bash/lib.args.sh
+++ b/lib-shared/tm/bash/lib.args.sh
@@ -10,7 +10,7 @@ fi
 #   _parse_args <options_string> <array_name>  <helpf_func> <args...>
 #
 # Parameters:
-#   --opt-<key> name/value pairs: '|name=value|name2=value2'. First chars is the value seperator (non alpha-numeric, e.g '|' or ';' etc)
+#   --opt-<key> name/value pairs: '|name=value|name2=value2'. First chars is the value separator (non alpha-numeric, e.g '|' or ';' etc)
 #                    - short         (optional) short option (e.g., "p"). Can be provided multiple times
 #                    - long          (optional) long option (e.g., "plain"). Defaults to the '<key>' if no short option provided. Can be provided multiple times
 #                    - flag          (optional) (flag) if no value to be taken, false by default (0)
@@ -22,11 +22,11 @@ fi
 #                    - desc          (optional) help text
 #                    - example       (optional) example text
 #                    - default       (optional) default value. Default is an empty string
-#                    - allowed       (optional) allowed values. First char is the value seperator if non alpha-numeric. Default is ','
+#                    - allowed       (optional) allowed values. First char is the value separator if non alpha-numeric. Default is ','
 #                    - validators|validator    (optional) comma separated validators
 #                                                     (+alphanumeric,+numbers,+letters,+nowhitespace,+noslash,+re:<pattern>,plugin-vendor,plugin-name,plugin-prefix).
 #                                                     If prefixed with  a '+', must pass (default), if prefixed with a '-', must fail validator
-#             If there are semi colons in any of the values, you can specify a different seperator, by setting the first char to the seperator (non alpahumeric)
+#             If there are semi colons in any of the values, you can specify a different separator, by setting the first char to the separator (non alphanumeric)
 #                      e.g. '|short=x|desc=The value for 'x', with a semicolon; This is also part of the the desc now'
 #   
 #   --result                  : (required) Name of the associative array to populate (passed by reference)
@@ -171,7 +171,7 @@ _tm::args::parse() {
               multi)
                   ref_array[multi]=1
                   ;;
-              multi_sep) # seperator to use when passing back multiple values
+              multi_sep) # separator to use when passing back multiple values
                   ref_array['multi-sep']="$value"
                   ;;
               remainder) # if set, then this key takes all the remainings args

--- a/lib-shared/tm/bash/lib.log.sh
+++ b/lib-shared/tm/bash/lib.log.sh
@@ -149,7 +149,7 @@ _tm::log::set_opts(){
         __tm_log_filters+=("${logger}")
         ;;
       *)
-        >&2 echo "WARN [_tm::log::opt_level] unknown log option '$opt', ignoring. Options are comma seperated. Include 'help' in the TM_LOG for all options. [finest,trace,debug,info,warn,help,all,caller,cfile,cfunc,datestamp,epoch,pid,timestamp,duration,user,stack]'"
+        >&2 echo "WARN [_tm::log::opt_level] unknown log option '$opt', ignoring. Options are comma separated. Include 'help' in the TM_LOG for all options. [finest,trace,debug,info,warn,help,all,caller,cfile,cfunc,datestamp,epoch,pid,timestamp,duration,user,stack]'"
         ;;
     esac
   done
@@ -158,7 +158,7 @@ _tm::log::set_opts(){
     >&2 cat << EOF
 _tm::log::set_opts \$TM_LOG (provided: $TM_LOG)
 
-Log options are comma seperated options. E.g. 'trace,all,stack,@foo*,@*bar*'
+Log options are comma separated options. E.g. 'trace,all,stack,@foo*,@*bar*'
 
 LEVEL OPTIONS:
  - finest|f

--- a/lib-shared/tm/bash/lib.util.sh
+++ b/lib-shared/tm/bash/lib.util.sh
@@ -691,7 +691,7 @@ _tm::util::add_to_path() {
     return
   fi
   _debug "adding paths $*"
-  # TODO: handle differnt seperator in different OS's?
+  # TODO: handle different separator in different OS's?
   IFS=':' read -ra current_paths <<< "$PATH"
   local path_exists
   for new_path in "$@"; do


### PR DESCRIPTION
## Summary
- correct several spelling mistakes in bash scripts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6868b276ea4483229e8b42c841323829